### PR TITLE
gold,currency,normals

### DIFF
--- a/Generic.filter
+++ b/Generic.filter
@@ -16,13 +16,13 @@ Show
 # Highlight Mid-Value Currency with Correct Colors and "Tink" Sound
 Show
  BaseType "Exalted Orb" "Regal Orb"
-    SetFontSize 40
-	SetTextColor 255 170 120 255 # Yellow text
-	SetBorderColor 255 170 120 255 # Yellow border
-	SetBackgroundColor 20 20 0 255 # Brown background
-	PlayAlertSound 2 300 # Mid-priority "tonk" sound
-	PlayEffect Yellow
-	MinimapIcon 0 Yellow Circle
+ SetFontSize 40
+ SetTextColor 150 0 0  # Red text
+ SetBorderColor 255 0 0  # Red border
+ SetBackgroundColor 255 255 255  # White background
+ PlayAlertSound 2 300  # High-priority "tink" sound
+ PlayEffect Red
+ MinimapIcon 0 Yellow Circle
 	
 # Highlight XYZ with Correct Colors and "Tink" Sound
 Show
@@ -54,7 +54,7 @@ Show # uniques
 # Gold
 ############################
 
-  # Highlight Gold with Bright Golden Background
+# Highlight Gold with Bright Golden Background
 Show
  BaseType "Gold"
  StackSize > 1000  # Only show stacks greater than 200
@@ -64,7 +64,7 @@ Show
  SetBackgroundColor 255 223 0  # Bright golden background
 
  
-  # Highlight Gold with Bright Golden Background
+# Highlight Gold with Bright Golden Background
 Show
  BaseType "Gold"
  StackSize > 200  # Only show stacks greater than 200
@@ -76,12 +76,13 @@ Show
 # Highlight Gold with Bright Golden Background
 Show
  BaseType "Gold"
+  StackSize > 1  # Only show stacks greater than 1 to not show items with "gold" other than gold
  SetFontSize 30  # Smaller font for lower priority
  SetTextColor 0 0 0  # Black text
  SetBorderColor 0 0 0  # Black border
  SetBackgroundColor 255 223 0  # Bright golden background
  
- ############################
+############################
 # Trial tokens
 ############################
  
@@ -151,7 +152,7 @@ Show
  PlayEffect Blue
  MinimapIcon 0 Blue Circle
  
- ############################
+############################
 # Jewlery
 ############################
 
@@ -202,7 +203,7 @@ Show # maps
  MinimapIcon 0 Red Square
 
 ############################
-# Rares/Sockets/Quality
+# Rares/Normals/Sockets/Quality
 ############################
 
 # Highlight Rare Items with Green Theme
@@ -228,3 +229,11 @@ Show
  SetTextColor 0 0 0  # Black text
  SetBorderColor 139 101 8  # Saddle brown border
  SetBackgroundColor 218 165 32  # Goldenrod background
+
+# Normal Items Smaller
+Show # Normal
+ Rarity Normal
+ SetFontSize 20
+ SetTextColor 255 255 255  # White text
+ SetBorderColor 0 0 0  # Black border
+ SetBackgroundColor 0 0 0  # Black background


### PR DESCRIPTION
- Normal items have smaller text
- Gold no longer picks up items with "gold" in text
- currency easier to see